### PR TITLE
fix for subscription event when there is no 'gifter'

### DIFF
--- a/root.js
+++ b/root.js
@@ -404,12 +404,13 @@ class SubscriptionEvent {
 		this.months = eventData.message[0].months;
 		this.sub_plan = eventData.message[0].sub_plan; //1000 = tier 1, 2000 = tier 2, Prime
 		this.message = eventData.message[0].message;
-		this.gifter = eventData.message[0].gifter;
 
-		if(eventData.message[0].gifter == ""){
-			console.log("No gifter");
-		}else{
-			console.log(eventData.message[0].gifter);
+		if(eventData.message[0].hasOwnProperty("gifter")){
+			this.gifter = eventData.message[0].gifter;
+		}
+		else
+		{
+			this.gifter = '';
 		}
 	}
 

--- a/root.js
+++ b/root.js
@@ -404,14 +404,12 @@ class SubscriptionEvent {
 		this.months = eventData.message[0].months;
 		this.sub_plan = eventData.message[0].sub_plan; //1000 = tier 1, 2000 = tier 2, Prime
 		this.message = eventData.message[0].message;
+		this.gifter = '';
 
-		if(eventData.message[0].hasOwnProperty("gifter")){
+		if(eventData.message[0].hasOwnProperty("gifter") && eventData.message[0].gifter){
 			this.gifter = eventData.message[0].gifter;
 		}
-		else
-		{
-			this.gifter = '';
-		}
+
 	}
 
 	process(){


### PR DESCRIPTION
I noticed in your screenshots and my tests that when you got a subscription and there wasn't a 'gifter' member in the messages object it we would see an `undefined` message in the log and bails on further execution. This could fix some of the problems you are having with events?!