### PR TITLE
Fix donations

### DIFF
--- a/root.js
+++ b/root.js
@@ -375,6 +375,7 @@ streamlabs.on('connect', function(){
 
 class DonationEvent {
 	parseJson(eventData){
+		console.log("New donation payload: ", eventData);
 		this.from = eventData.message[0].from;
 		this.message = eventData.message[0].message;
 		this.amount = eventData.message[0].amount;

--- a/root.js
+++ b/root.js
@@ -979,6 +979,7 @@ function donoAlert(msgData, msgAmount, msgMessage, msgType, msgCurrency){
 			_root.MAINCONTAINER.getChildByName("charAnim").banner.txtDetails.text = "cheered " + msgAmount + " bits!";
 			_root.MAINCONTAINER.getChildByName("charAnim").plusAmount.txtAmount.text = "+" + msgAmount;
 		}else{
+			msgAmount = Number.parseFloat(msgAmount).toFixed(2);
 			_root.MAINCONTAINER.getChildByName("charAnim").banner.txtDetails.text = "tipped " + msgCurrency + " " + msgAmount +"!";
 			_root.MAINCONTAINER.getChildByName("charAnim").plusAmount.txtAmount.text = "+" + msgAmount + " " + msgCurrency;
 		}	


### PR DESCRIPTION
I did two things here:
* First I added some debug logging for the donation payload. I'm still curious why re-playing the event is different than live. And with that you can compare both event payloads, and see what streamlabs sends. The documentation says it should be a string. This can be reverted later, once we know what streamlabs sends.
* I formatted the donation amount to always have two digits after the decimal point. This shows one dollar always as "1.00" without a million zeros, but always with two. "3.7865592293594657" is shown as "3.79".